### PR TITLE
Mention the potential need for port forwarding.

### DIFF
--- a/site/content/docs/faq.md
+++ b/site/content/docs/faq.md
@@ -1,0 +1,17 @@
++++
+Categories = []
+Description = ""
+Tags = [tips]
+menu = "main"
+title = "FAQ"
+date = 2014-08-06T04:37:14Z
++++
+
+# Port Forwarding for Shipyard running in a VM
+
+The docker commands given in the [Shipyard Quickstart](http://shipyard-project.com/docs/quickstart/)
+associate the port 8080 on the docker UI container with port 8080 on the docker machine. However, if that docker machine is running as a VM, as any Mac OSX or windows installation will be, you may want to forward that port to its host OS. 
+
+An ad-hoc solution is to use an ssh tunnel: `ssh [YOUR_USER@YOUR_DOCKER_MACHINE_IP] -L 8080:localhost:8080` -- the first number is the port on your host machine, the second is the target port on the docker machine. [Boot2docker](http://boot2docker.io/) users can do this easily by running `boot2docker ssh -L 8080:localhost:8080`. 
+
+Permanent setup of port forwarding is handled by the virtualization layer -- not shipyard or docker -- so you'll have to consult the VM provider documentation. Boot2Docker users can find several ways to accomplish [port forwarding described in the Boot2Docker docs](https://github.com/boot2docker/boot2docker/blob/master/doc/WORKAROUNDS.md).

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -32,6 +32,8 @@ docker run -it -p 8080:8080 -d --name shipyard \
 
 Shipyard will create a default user account with the username `admin` and the password `shipyard`.  You should then be able to open a browser to `http://<your-host-ip>:8080` and see the Shipyard login.
 
+> Note: If docker is running within a VM, you probably want to additionally [forward the Shipyard UI port to the host OS](/docs/faq/#port-forwarding-for-shipyard-running-in-a-vm). For example, Boot2Docker users on OSX can run `boot2docker ssh -L 8080:localhost:8080` and then connect to `http://localhost:8080/` from their browser of choice.
+
 # Engine
 You can then either use the web UI or the CLI to add an engine.  
 


### PR DESCRIPTION
OSX users (or anyone else running docker in a VM) may not know that there is an additional step to access the docker UI from their browser. Users new to docker may not even yet appreciate the distinction between the docker OS/container interations and the VM host machine / VM guest machine interactions. It's worth calling this out in the Quickstart, and giving an extended description in an FAQ page.